### PR TITLE
feat: fetch photos via api

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,8 +3,10 @@
 /* eslint-disable @next/next/no-img-element */
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import styles from "./home.module.css";
 import { getCookie, onAuthSessionChange } from "@/shared/auth/session";
+import { getPhotos } from "@/shared/api/photos";
 
 export default function Home() {
   const [username, setUsername] = useState<string | null>(null);
@@ -15,6 +17,15 @@ export default function Home() {
     update();
     return onAuthSessionChange(update);
   }, []);
+  const {
+    data: photos = [],
+    isLoading: photosLoading,
+    isError: photosError,
+  } = useQuery({
+    queryKey: ["photos"],
+    queryFn: getPhotos,
+    enabled: !!username && active === "photos",
+  });
 
   if (!username) {
     const images = Array.from({ length: 6 }).map((_, i) => (
@@ -29,7 +40,9 @@ export default function Home() {
       <main className={styles.main}>
         <section className={styles.hero}>
           <h1 className={styles.title}>Lazy Photos</h1>
-          <p className={styles.tagline}>Store your memories like a true geek.</p>
+          <p className={styles.tagline}>
+            Store your memories like a true geek.
+          </p>
           <div className={styles.actions}>
             <Link href="/login" className={styles.login}>
               Login
@@ -44,18 +57,25 @@ export default function Home() {
     );
   }
 
-  const photos = Array.from({ length: 8 }).map((_, i) => (
-    <img
-      key={i}
-      src={`https://picsum.photos/seed/auth${i}/300/200`}
-      alt={`Photo ${i + 1}`}
-    />
-  ));
-
   const albums = [
-    { id: 1, name: "Vacation", count: 42, thumb: "https://picsum.photos/seed/album1/300/200" },
-    { id: 2, name: "Family", count: 18, thumb: "https://picsum.photos/seed/album2/300/200" },
-    { id: 3, name: "Work", count: 5, thumb: "https://picsum.photos/seed/album3/300/200" }
+    {
+      id: 1,
+      name: "Vacation",
+      count: 42,
+      thumb: "https://picsum.photos/seed/album1/300/200",
+    },
+    {
+      id: 2,
+      name: "Family",
+      count: 18,
+      thumb: "https://picsum.photos/seed/album2/300/200",
+    },
+    {
+      id: 3,
+      name: "Work",
+      count: 5,
+      thumb: "https://picsum.photos/seed/album3/300/200",
+    },
   ];
 
   return (
@@ -79,7 +99,17 @@ export default function Home() {
       </aside>
       <section className={styles.content}>
         {active === "photos" ? (
-          <div className={styles.photoGrid}>{photos}</div>
+          photosLoading ? (
+            <p>Loading photos...</p>
+          ) : photosError ? (
+            <p>Failed to load photos</p>
+          ) : (
+            <div className={styles.photoGrid}>
+              {photos.map((photo) => (
+                <img key={photo.id} src={photo.url} alt={`Photo ${photo.id}`} />
+              ))}
+            </div>
+          )
         ) : (
           <div className={styles.albumGrid}>
             {albums.map((album) => (
@@ -87,7 +117,9 @@ export default function Home() {
                 <img src={album.thumb} alt={`${album.name} cover`} />
                 <div className={styles.albumInfo}>
                   <span className={styles.albumName}>{album.name}</span>
-                  <span className={styles.albumCount}>{album.count} photos</span>
+                  <span className={styles.albumCount}>
+                    {album.count} photos
+                  </span>
                 </div>
               </div>
             ))}

--- a/src/shared/api/photos.ts
+++ b/src/shared/api/photos.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { API_BASE_URL } from "../config";
+import { getCookie } from "../auth/session";
+import { OpenAPI, PhotoService } from "./generated";
+
+OpenAPI.BASE = API_BASE_URL;
+OpenAPI.TOKEN = async () => getCookie("accessToken") || "";
+
+const PhotoSchema = z.object({
+  id: z.number(),
+  url: z.string().url(),
+});
+
+const PhotosSchema = z.array(PhotoSchema);
+export type Photo = z.infer<typeof PhotoSchema>;
+
+export async function getPhotos(): Promise<Photo[]> {
+  try {
+    const res = await PhotoService.getApiPhoto();
+    return PhotosSchema.parse(res);
+  } catch (err) {
+    const body = (err as any)?.body as { message?: string } | undefined;
+    const message =
+      body?.message ??
+      (err instanceof Error ? err.message : "Failed to load photos");
+    throw new Error(message);
+  }
+}

--- a/tests/unit/photos.test.ts
+++ b/tests/unit/photos.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+describe("getPhotos", () => {
+  it("calls the photos endpoint and resolves with data", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => [{ id: 1, url: "https://img/1" }],
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { getPhotos } = await import("../../src/shared/api/photos");
+    await expect(getPhotos()).resolves.toEqual([
+      { id: 1, url: "https://img/1" },
+    ]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/api/Photo",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("throws with server message", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => ({ message: "boom" }),
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { getPhotos } = await import("../../src/shared/api/photos");
+    await expect(getPhotos()).rejects.toThrow("boom");
+  });
+});


### PR DESCRIPTION
## Summary
- load photos via API in home page photos tab
- add photos API helper with zod validation
- cover photos API with unit tests

## Testing
- `pnpm lint`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6893cc0124e88322bcb822d870814a4a