### PR TITLE
feat: load and create albums

### DIFF
--- a/app/home.module.css
+++ b/app/home.module.css
@@ -112,6 +112,17 @@
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
 
+.albumForm {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.albumInput {
+  flex: 1;
+  padding: 0.5rem;
+}
+
 .photoGrid img {
   width: 100%;
   height: auto;

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -112,17 +112,6 @@
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
 
-.albumForm {
-  margin-bottom: 1rem;
-  display: flex;
-  gap: 0.5rem;
-}
-
-.albumInput {
-  flex: 1;
-  padding: 0.5rem;
-}
-
 .photoGrid img {
   width: 100%;
   height: auto;
@@ -156,6 +145,15 @@
 
 .albumCount {
   font-size: 0.875rem;
+}
+
+.albumAdd {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 3rem;
+  background: none;
+  cursor: pointer;
 }
 
 @media (max-width: 600px) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,11 +43,9 @@ export default function Home() {
   });
 
   const queryClient = useQueryClient();
-  const [albumName, setAlbumName] = useState("");
   const createAlbumMutation = useMutation({
     mutationFn: createAlbum,
     onSuccess: () => {
-      setAlbumName("");
       queryClient.invalidateQueries({ queryKey: ["albums"] });
     },
   });
@@ -123,40 +121,31 @@ export default function Home() {
         ) : albumsError ? (
           <p>Failed to load albums</p>
         ) : (
-          <>
-            <form
-              className={styles.albumForm}
-              onSubmit={(e) => {
-                e.preventDefault();
-                if (albumName) {
-                  createAlbumMutation.mutate(albumName);
+          <div className={styles.albumGrid}>
+            <button
+              className={`${styles.albumItem} ${styles.albumAdd}`}
+              onClick={() => {
+                const name = window.prompt("Album name?");
+                if (name) {
+                  createAlbumMutation.mutate(name);
                 }
               }}
+              aria-label="Create album"
             >
-              <input
-                className={styles.albumInput}
-                value={albumName}
-                onChange={(e) => setAlbumName(e.target.value)}
-                placeholder="New album name"
-              />
-              <button type="submit">Create</button>
-            </form>
-            <div className={styles.albumGrid}>
-              {albums.map((album) => (
-                <div key={album.id} className={styles.albumItem}>
-                  {album.thumb && (
-                    <img src={album.thumb} alt={`${album.name} cover`} />
-                  )}
-                  <div className={styles.albumInfo}>
-                    <span className={styles.albumName}>{album.name}</span>
-                    <span className={styles.albumCount}>
-                      {album.count} photos
-                    </span>
-                  </div>
+              +
+            </button>
+            {albums.map((album) => (
+              <div key={album.id} className={styles.albumItem}>
+                {album.thumb && (
+                  <img src={album.thumb} alt={`${album.name} cover`} />
+                )}
+                <div className={styles.albumInfo}>
+                  <span className={styles.albumName}>{album.name}</span>
+                  <span className={styles.albumCount}>{album.count} photos</span>
                 </div>
-              ))}
-            </div>
-          </>
+              </div>
+            ))}
+          </div>
         )}
       </section>
     </main>

--- a/src/shared/api/albums.ts
+++ b/src/shared/api/albums.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { API_BASE_URL } from "../config";
+import { getCookie } from "../auth/session";
+import { OpenAPI, AlbumService } from "./generated";
+
+OpenAPI.BASE = API_BASE_URL;
+OpenAPI.TOKEN = async () => getCookie("accessToken") || "";
+
+const AlbumSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  count: z.number(),
+  thumb: z.string().url().optional(),
+});
+
+const AlbumsSchema = z.array(AlbumSchema);
+export type Album = z.infer<typeof AlbumSchema>;
+
+export async function getAlbums(): Promise<Album[]> {
+  try {
+    const res = await AlbumService.getAlbums();
+    return AlbumsSchema.parse(res);
+  } catch (err) {
+    const body = (err as any)?.body as { message?: string } | undefined;
+    const message =
+      body?.message ??
+      (err instanceof Error ? err.message : "Failed to load albums");
+    throw new Error(message);
+  }
+}
+
+export async function createAlbum(name: string): Promise<void> {
+  try {
+    await AlbumService.postAlbumCreateAlbum(name);
+  } catch (err) {
+    const body = (err as any)?.body as { message?: string } | undefined;
+    const message =
+      body?.message ??
+      (err instanceof Error ? err.message : "Failed to create album");
+    throw new Error(message);
+  }
+}
+

--- a/tests/unit/albums.test.ts
+++ b/tests/unit/albums.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  delete (globalThis as any).document;
+});
+
+describe("albums api", () => {
+  it("fetches albums with auth header", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    (globalThis as any).document = { cookie: "accessToken=token" };
+    const mockAlbum = {
+      id: 1,
+      name: "Vacation",
+      count: 10,
+      thumb: "https://example.com/thumb.jpg",
+    };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => [mockAlbum],
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { getAlbums } = await import("../../src/shared/api/albums");
+    await expect(getAlbums()).resolves.toEqual([mockAlbum]);
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init?.method).toBe("GET");
+    expect((init?.headers as Headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+
+  it("throws with server message", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => ({ message: "boom" }),
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { getAlbums } = await import("../../src/shared/api/albums");
+    await expect(getAlbums()).rejects.toThrow("boom");
+  });
+
+  it("posts album name", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    (globalThis as any).document = { cookie: "accessToken=token" };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => ({}),
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { createAlbum } = await import("../../src/shared/api/albums");
+    await expect(createAlbum("Holiday")).resolves.toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/Album/CreateAlbum?albumName=Holiday",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const [, init] = mockFetch.mock.calls[0];
+    expect((init?.headers as Headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+
+  it("propagates server error on create", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => ({ message: "fail" }),
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { createAlbum } = await import("../../src/shared/api/albums");
+    await expect(createAlbum("Holiday")).rejects.toThrow("fail");
+  });
+});
+


### PR DESCRIPTION
## Summary
- fetch albums via API with validation
- allow creating new albums from home page
- add unit tests for album API and update styles

## Testing
- `npm test`
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68ac6eb27f188322afbe3321d5d56365