### PR TITLE
feat: add album API client and tests

### DIFF
--- a/app/home.module.css
+++ b/app/home.module.css
@@ -147,6 +147,16 @@
   font-size: 0.875rem;
 }
 
+.createAlbum {
+  margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
+  border: 2px solid #00ff00;
+  background: none;
+  color: #00ff00;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
 @media (max-width: 600px) {
   .title {
     font-size: 2rem;

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -132,6 +132,16 @@
   display: block;
 }
 
+.albumPlaceholder {
+  width: 100%;
+  height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #111;
+  color: #777;
+}
+
 .albumInfo {
   padding: 0.5rem;
   display: flex;

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -202,6 +202,24 @@
   gap: 0.5rem;
 }
 
+.modalButton {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.modalConfirm {
+  background: #00ff00;
+  color: #000;
+  border: none;
+}
+
+.modalCancel {
+  border: 2px solid #00ff00;
+  background: none;
+  color: #00ff00;
+}
+
 @media (max-width: 600px) {
   .title {
     font-size: 2rem;

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -167,6 +167,41 @@
   cursor: pointer;
 }
 
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: #000;
+  border: 1px solid #00ff00;
+  border-radius: 4px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.input {
+  padding: 0.5rem;
+  border: 1px solid #00ff00;
+  background: transparent;
+  color: inherit;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
 @media (max-width: 600px) {
   .title {
     font-size: 2rem;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,14 +3,16 @@
 /* eslint-disable @next/next/no-img-element */
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import styles from "./home.module.css";
 import { getCookie, onAuthSessionChange } from "@/shared/auth/session";
 import { getPhotos } from "@/shared/api/photos";
+import { getAlbums, createAlbum } from "@/shared/api/albums";
 
 export default function Home() {
   const [username, setUsername] = useState<string | null>(null);
   const [active, setActive] = useState<"photos" | "albums">("photos");
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     const update = () => setUsername(getCookie("username"));
@@ -26,6 +28,27 @@ export default function Home() {
     queryFn: getPhotos,
     enabled: !!username && active === "photos",
   });
+
+  const {
+    data: albums = [],
+    isLoading: albumsLoading,
+    isError: albumsError,
+  } = useQuery({
+    queryKey: ["albums"],
+    queryFn: getAlbums,
+    enabled: !!username && active === "albums",
+  });
+
+  const handleCreateAlbum = async () => {
+    const name = prompt("Album name");
+    if (!name) return;
+    try {
+      await createAlbum(name);
+      queryClient.invalidateQueries({ queryKey: ["albums"] });
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to create album");
+    }
+  };
 
   if (!username) {
     const images = Array.from({ length: 6 }).map((_, i) => (
@@ -56,27 +79,6 @@ export default function Home() {
       </main>
     );
   }
-
-  const albums = [
-    {
-      id: 1,
-      name: "Vacation",
-      count: 42,
-      thumb: "https://picsum.photos/seed/album1/300/200",
-    },
-    {
-      id: 2,
-      name: "Family",
-      count: 18,
-      thumb: "https://picsum.photos/seed/album2/300/200",
-    },
-    {
-      id: 3,
-      name: "Work",
-      count: 5,
-      thumb: "https://picsum.photos/seed/album3/300/200",
-    },
-  ];
 
   return (
     <main className={styles.appContainer}>
@@ -114,20 +116,25 @@ export default function Home() {
               ))}
             </div>
           )
+        ) : albumsLoading ? (
+          <p>Loading albums...</p>
+        ) : albumsError ? (
+          <p>Failed to load albums</p>
         ) : (
-          <div className={styles.albumGrid}>
-            {albums.map((album) => (
-              <div key={album.id} className={styles.albumItem}>
-                <img src={album.thumb} alt={`${album.name} cover`} />
-                <div className={styles.albumInfo}>
-                  <span className={styles.albumName}>{album.name}</span>
-                  <span className={styles.albumCount}>
-                    {album.count} photos
-                  </span>
+          <>
+            <button className={styles.createAlbum} onClick={handleCreateAlbum}>
+              Create album
+            </button>
+            <div className={styles.albumGrid}>
+              {albums.map((album) => (
+                <div key={album.id} className={styles.albumItem}>
+                  <div className={styles.albumInfo}>
+                    <span className={styles.albumName}>{album.name}</span>
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          </>
         )}
       </section>
     </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -143,8 +143,16 @@ export default function Home() {
                     placeholder="Album name"
                   />
                   <div className={styles.modalActions}>
-                    <button onClick={submitCreateAlbum}>Create</button>
-                    <button onClick={() => setShowAlbumModal(false)}>
+                    <button
+                      className={`${styles.modalButton} ${styles.modalConfirm}`}
+                      onClick={submitCreateAlbum}
+                    >
+                      Create
+                    </button>
+                    <button
+                      className={`${styles.modalButton} ${styles.modalCancel}`}
+                      onClick={() => setShowAlbumModal(false)}
+                    >
                       Cancel
                     </button>
                   </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,8 @@ import { getAlbums, createAlbum } from "@/shared/api/albums";
 export default function Home() {
   const [username, setUsername] = useState<string | null>(null);
   const [active, setActive] = useState<"photos" | "albums">("photos");
+  const [showAlbumModal, setShowAlbumModal] = useState(false);
+  const [albumTitle, setAlbumTitle] = useState("");
   const queryClient = useQueryClient();
 
   useEffect(() => {
@@ -39,12 +41,17 @@ export default function Home() {
     enabled: !!username && active === "albums",
   });
 
-  const handleCreateAlbum = async () => {
-    const name = prompt("Album name");
-    if (!name) return;
+  const openCreateAlbum = () => {
+    setAlbumTitle("");
+    setShowAlbumModal(true);
+  };
+
+  const submitCreateAlbum = async () => {
+    if (!albumTitle.trim()) return;
     try {
-      await createAlbum(name);
+      await createAlbum(albumTitle.trim());
       queryClient.invalidateQueries({ queryKey: ["albums"] });
+      setShowAlbumModal(false);
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to create album");
     }
@@ -122,9 +129,28 @@ export default function Home() {
           <p>Failed to load albums</p>
         ) : (
           <>
-            <button className={styles.createAlbum} onClick={handleCreateAlbum}>
+            <button className={styles.createAlbum} onClick={openCreateAlbum}>
               Create album
             </button>
+            {showAlbumModal && (
+              <div className={styles.modalOverlay}>
+                <div className={styles.modal}>
+                  <h3>Create album</h3>
+                  <input
+                    className={styles.input}
+                    value={albumTitle}
+                    onChange={(e) => setAlbumTitle(e.target.value)}
+                    placeholder="Album name"
+                  />
+                  <div className={styles.modalActions}>
+                    <button onClick={submitCreateAlbum}>Create</button>
+                    <button onClick={() => setShowAlbumModal(false)}>
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
             <div className={styles.albumGrid}>
               {albums.map((album) => (
                 <div key={album.id} className={styles.albumItem}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -128,8 +128,16 @@ export default function Home() {
             <div className={styles.albumGrid}>
               {albums.map((album) => (
                 <div key={album.id} className={styles.albumItem}>
+                  {album.thumbnailPath ? (
+                    <img src={album.thumbnailPath} alt={album.title} />
+                  ) : (
+                    <div className={styles.albumPlaceholder}>No image</div>
+                  )}
                   <div className={styles.albumInfo}>
-                    <span className={styles.albumName}>{album.name}</span>
+                    <span className={styles.albumName}>{album.title}</span>
+                    <span className={styles.albumCount}>
+                      {album.photoCount} photos
+                    </span>
                   </div>
                 </div>
               ))}

--- a/src/shared/api/albums.ts
+++ b/src/shared/api/albums.ts
@@ -9,7 +9,9 @@ OpenAPI.TOKEN = async () => getCookie("accessToken") || "";
 
 const AlbumSchema = z.object({
   id: z.number(),
-  name: z.string(),
+  title: z.string(),
+  photoCount: z.number(),
+  thumbnailPath: z.string().nullable(),
 });
 
 const AlbumsSchema = z.array(AlbumSchema);

--- a/src/shared/api/albums.ts
+++ b/src/shared/api/albums.ts
@@ -45,7 +45,11 @@ export async function getAlbum(id: number): Promise<Album> {
 
 export async function createAlbum(albumName: string): Promise<Album> {
   try {
-    const res = await AlbumService.postAlbumCreateAlbum(albumName);
+    const res = await __request(OpenAPI, {
+      method: "POST",
+      url: "/Album",
+      query: { albumName },
+    });
     return AlbumSchema.parse(res);
   } catch (err) {
     const body = (err as any)?.body as { message?: string } | undefined;

--- a/src/shared/api/albums.ts
+++ b/src/shared/api/albums.ts
@@ -31,7 +31,7 @@ export async function getAlbums(): Promise<Album[]> {
 
 export async function getAlbum(id: number): Promise<Album> {
   try {
-    const res = await AlbumService.getAlbumById(id);
+    const res = await AlbumService.getAlbumById(String(id));
     return AlbumSchema.parse(res);
   } catch (err) {
     const body = (err as any)?.body as { message?: string } | undefined;
@@ -42,10 +42,12 @@ export async function getAlbum(id: number): Promise<Album> {
   }
 }
 
-export async function createAlbum(title: string): Promise<Album> {
+export async function createAlbum(
+  title: string,
+  photoIds: number[] = [],
+): Promise<void> {
   try {
-    const res = await AlbumService.createAlbum({ title });
-    return AlbumSchema.parse(res);
+    await AlbumService.postAlbum(title, photoIds);
   } catch (err) {
     const body = (err as any)?.body as { message?: string } | undefined;
     const message =

--- a/src/shared/api/albums.ts
+++ b/src/shared/api/albums.ts
@@ -45,7 +45,7 @@ export async function getAlbum(id: number): Promise<Album> {
 
 export async function createAlbum(albumName: string): Promise<Album> {
   try {
-    const res = await AlbumService.createAlbum({ title: albumName });
+    const res = await AlbumService.postAlbumCreateAlbum(albumName);
     return AlbumSchema.parse(res);
   } catch (err) {
     const body = (err as any)?.body as { message?: string } | undefined;

--- a/src/shared/api/albums.ts
+++ b/src/shared/api/albums.ts
@@ -45,11 +45,7 @@ export async function getAlbum(id: number): Promise<Album> {
 
 export async function createAlbum(albumName: string): Promise<Album> {
   try {
-    const res = await __request(OpenAPI, {
-      method: "POST",
-      url: "/Album",
-      query: { albumName },
-    });
+    const res = await AlbumService.createAlbum({ title: albumName });
     return AlbumSchema.parse(res);
   } catch (err) {
     const body = (err as any)?.body as { message?: string } | undefined;

--- a/src/shared/api/albums.ts
+++ b/src/shared/api/albums.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { API_BASE_URL } from "../config";
+import { getCookie } from "../auth/session";
+import { OpenAPI, AlbumService } from "./generated";
+import { request as __request } from "./generated/core/request";
+
+OpenAPI.BASE = API_BASE_URL;
+OpenAPI.TOKEN = async () => getCookie("accessToken") || "";
+
+const AlbumSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
+const AlbumsSchema = z.array(AlbumSchema);
+export type Album = z.infer<typeof AlbumSchema>;
+
+export async function getAlbums(): Promise<Album[]> {
+  try {
+    const res = await AlbumService.getAlbums();
+    return AlbumsSchema.parse(res);
+  } catch (err) {
+    const body = (err as any)?.body as { message?: string } | undefined;
+    const message =
+      body?.message ??
+      (err instanceof Error ? err.message : "Failed to load albums");
+    throw new Error(message);
+  }
+}
+
+export async function getAlbum(id: number): Promise<Album> {
+  try {
+    const res = await AlbumService.getAlbumById(id);
+    return AlbumSchema.parse(res);
+  } catch (err) {
+    const body = (err as any)?.body as { message?: string } | undefined;
+    const message =
+      body?.message ??
+      (err instanceof Error ? err.message : "Failed to load album");
+    throw new Error(message);
+  }
+}
+
+export async function createAlbum(albumName: string): Promise<Album> {
+  try {
+    const res = await AlbumService.postAlbumCreateAlbum(albumName);
+    return AlbumSchema.parse(res);
+  } catch (err) {
+    const body = (err as any)?.body as { message?: string } | undefined;
+    const message =
+      body?.message ??
+      (err instanceof Error ? err.message : "Failed to create album");
+    throw new Error(message);
+  }
+}
+
+export async function deleteAlbum(id: number): Promise<void> {
+  try {
+    await __request(OpenAPI, {
+      method: "DELETE",
+      url: "/Album/{id}",
+      path: { id },
+    });
+  } catch (err) {
+    const body = (err as any)?.body as { message?: string } | undefined;
+    const message =
+      body?.message ??
+      (err instanceof Error ? err.message : "Failed to delete album");
+    throw new Error(message);
+  }
+}
+

--- a/src/shared/api/albums.ts
+++ b/src/shared/api/albums.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { API_BASE_URL } from "../config";
 import { getCookie } from "../auth/session";
 import { OpenAPI, AlbumService } from "./generated";
-import { request as __request } from "./generated/core/request";
 
 OpenAPI.BASE = API_BASE_URL;
 OpenAPI.TOKEN = async () => getCookie("accessToken") || "";
@@ -43,9 +42,9 @@ export async function getAlbum(id: number): Promise<Album> {
   }
 }
 
-export async function createAlbum(albumName: string): Promise<Album> {
+export async function createAlbum(title: string): Promise<Album> {
   try {
-    const res = await AlbumService.postAlbumCreateAlbum(albumName);
+    const res = await AlbumService.createAlbum({ title });
     return AlbumSchema.parse(res);
   } catch (err) {
     const body = (err as any)?.body as { message?: string } | undefined;
@@ -58,11 +57,7 @@ export async function createAlbum(albumName: string): Promise<Album> {
 
 export async function deleteAlbum(id: number): Promise<void> {
   try {
-    await __request(OpenAPI, {
-      method: "DELETE",
-      url: "/Album/{id}",
-      path: { id },
-    });
+    await AlbumService.deleteAlbum(id);
   } catch (err) {
     const body = (err as any)?.body as { message?: string } | undefined;
     const message =

--- a/src/shared/api/generated/index.ts
+++ b/src/shared/api/generated/index.ts
@@ -8,7 +8,6 @@ export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
 export type { AccessTokenResponse } from './models/AccessTokenResponse';
-export type { CreateAlbumRequest } from './models/CreateAlbumRequest';
 export type { ForgotPasswordRequest } from './models/ForgotPasswordRequest';
 export type { HttpValidationProblemDetails } from './models/HttpValidationProblemDetails';
 export type { InfoRequest } from './models/InfoRequest';

--- a/src/shared/api/generated/index.ts
+++ b/src/shared/api/generated/index.ts
@@ -8,6 +8,7 @@ export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
 export type { AccessTokenResponse } from './models/AccessTokenResponse';
+export type { AlbumModel } from './models/AlbumModel';
 export type { ForgotPasswordRequest } from './models/ForgotPasswordRequest';
 export type { HttpValidationProblemDetails } from './models/HttpValidationProblemDetails';
 export type { InfoRequest } from './models/InfoRequest';

--- a/src/shared/api/generated/index.ts
+++ b/src/shared/api/generated/index.ts
@@ -8,6 +8,7 @@ export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
 export type { AccessTokenResponse } from './models/AccessTokenResponse';
+export type { CreateAlbumRequest } from './models/CreateAlbumRequest';
 export type { ForgotPasswordRequest } from './models/ForgotPasswordRequest';
 export type { HttpValidationProblemDetails } from './models/HttpValidationProblemDetails';
 export type { InfoRequest } from './models/InfoRequest';

--- a/src/shared/api/generated/models/AlbumModel.ts
+++ b/src/shared/api/generated/models/AlbumModel.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type AlbumModel = {
+    title: string | null;
+    photoCount: number;
+    thumbnailPath?: string | null;
+    id: number;
+};
+

--- a/src/shared/api/generated/models/CreateAlbumRequest.ts
+++ b/src/shared/api/generated/models/CreateAlbumRequest.ts
@@ -1,8 +1,0 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
-export type CreateAlbumRequest = {
-    title: string;
-};
-

--- a/src/shared/api/generated/models/CreateAlbumRequest.ts
+++ b/src/shared/api/generated/models/CreateAlbumRequest.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type CreateAlbumRequest = {
+    title: string;
+};
+

--- a/src/shared/api/generated/services/AlbumService.ts
+++ b/src/shared/api/generated/services/AlbumService.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { CreateAlbumRequest } from '../models/CreateAlbumRequest';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -17,6 +18,21 @@ export class AlbumService {
         });
     }
     /**
+     * @param requestBody
+     * @returns any OK
+     * @throws ApiError
+     */
+    public static createAlbum(
+        requestBody: CreateAlbumRequest,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/Album',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
      * @param id
      * @returns any OK
      * @throws ApiError
@@ -29,22 +45,6 @@ export class AlbumService {
             url: '/Album/{id}',
             path: {
                 'id': id,
-            },
-        });
-    }
-    /**
-     * @param albumName
-     * @returns any OK
-     * @throws ApiError
-     */
-    public static postAlbumCreateAlbum(
-        albumName?: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/Album/CreateAlbum',
-            query: {
-                'albumName': albumName,
             },
         });
     }

--- a/src/shared/api/generated/services/AlbumService.ts
+++ b/src/shared/api/generated/services/AlbumService.ts
@@ -17,6 +17,23 @@ export class AlbumService {
         });
     }
     /**
+     * @param requestBody
+     * @returns any OK
+     * @throws ApiError
+     */
+    public static createAlbum(
+        requestBody: {
+            title: string;
+        },
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/Album',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
      * @param id
      * @returns any OK
      * @throws ApiError
@@ -33,18 +50,18 @@ export class AlbumService {
         });
     }
     /**
-     * @param albumName
+     * @param id
      * @returns any OK
      * @throws ApiError
      */
-    public static postAlbumCreateAlbum(
-        albumName?: string,
+    public static deleteAlbum(
+        id: number,
     ): CancelablePromise<any> {
         return __request(OpenAPI, {
-            method: 'POST',
-            url: '/Album/CreateAlbum',
-            query: {
-                'albumName': albumName,
+            method: 'DELETE',
+            url: '/Album/{id}',
+            path: {
+                'id': id,
             },
         });
     }

--- a/src/shared/api/generated/services/AlbumService.ts
+++ b/src/shared/api/generated/services/AlbumService.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { CreateAlbumRequest } from '../models/CreateAlbumRequest';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -18,21 +17,6 @@ export class AlbumService {
         });
     }
     /**
-     * @param requestBody
-     * @returns any OK
-     * @throws ApiError
-     */
-    public static createAlbum(
-        requestBody: CreateAlbumRequest,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/Album',
-            body: requestBody,
-            mediaType: 'application/json',
-        });
-    }
-    /**
      * @param id
      * @returns any OK
      * @throws ApiError
@@ -45,6 +29,22 @@ export class AlbumService {
             url: '/Album/{id}',
             path: {
                 'id': id,
+            },
+        });
+    }
+    /**
+     * @param albumName
+     * @returns any OK
+     * @throws ApiError
+     */
+    public static postAlbumCreateAlbum(
+        albumName?: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/Album/CreateAlbum',
+            query: {
+                'albumName': albumName,
             },
         });
     }

--- a/src/shared/api/generated/services/AlbumService.ts
+++ b/src/shared/api/generated/services/AlbumService.ts
@@ -2,45 +2,58 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AlbumModel } from '../models/AlbumModel';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 export class AlbumService {
     /**
-     * @returns any OK
+     * Retrieves a list of available albums.
+     * This method returns all albums currently available in the system. If no albums are available,
+     * the response will contain an empty list.
+     * @returns AlbumModel OK
      * @throws ApiError
      */
-    public static getAlbums(): CancelablePromise<any> {
+    public static getAlbums(): CancelablePromise<Array<AlbumModel>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/Album',
         });
     }
     /**
-     * @param requestBody
+     * Creates a new album with the specified name and associated photos.
+     * This method creates a new album and associates the specified photos with it.  The album is
+     * created asynchronously, and the operation can be canceled using the provided ct.
+     * @param albumName The name of the album to create. Cannot be null or empty.
+     * @param requestBody An array of photo IDs to associate with the album. The array can be empty, but cannot be null.
      * @returns any OK
      * @throws ApiError
      */
-    public static createAlbum(
-        requestBody: {
-            title: string;
-        },
+    public static postAlbum(
+        albumName?: string,
+        requestBody?: Array<number>,
     ): CancelablePromise<any> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/Album',
+            query: {
+                'albumName': albumName,
+            },
             body: requestBody,
             mediaType: 'application/json',
         });
     }
     /**
+     * Retrieves an album by its unique identifier.
+     * The id must correspond to an existing album in the system. If the album does
+     * not exist, the response will indicate an error.
      * @param id
-     * @returns any OK
+     * @returns AlbumModel OK
      * @throws ApiError
      */
     public static getAlbumById(
-        id: number,
-    ): CancelablePromise<any> {
+        id: string,
+    ): CancelablePromise<AlbumModel> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/Album/{id}',
@@ -50,18 +63,21 @@ export class AlbumService {
         });
     }
     /**
-     * @param id
+     * Deletes the album with the specified identifier.
+     * This operation is idempotent. If the specified album does not exist, the method still returns
+     * Microsoft.AspNetCore.Mvc.NoContentResult.
+     * @param albumId The unique identifier of the album to delete.
      * @returns any OK
      * @throws ApiError
      */
     public static deleteAlbum(
-        id: number,
+        albumId: number,
     ): CancelablePromise<any> {
         return __request(OpenAPI, {
             method: 'DELETE',
-            url: '/Album/{id}',
+            url: '/Album/{albumId}',
             path: {
-                'id': id,
+                'albumId': albumId,
             },
         });
     }

--- a/src/shared/api/users.ts
+++ b/src/shared/api/users.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { API_BASE_URL } from "../config";
+import { getCookie } from "../auth/session";
+import { OpenAPI, UserService } from "./generated";
+
+OpenAPI.BASE = API_BASE_URL;
+OpenAPI.TOKEN = async () => getCookie("accessToken") || "";
+
+const UserSchema = z.object({
+  id: z.string(),
+  userName: z.string(),
+  email: z.string().email(),
+});
+
+export type User = z.infer<typeof UserSchema>;
+
+export async function getCurrentUser(): Promise<User> {
+  try {
+    const res = await UserService.currentUser();
+    return UserSchema.parse(res);
+  } catch (err) {
+    const body = (err as any)?.body as { message?: string } | undefined;
+    const message =
+      body?.message ??
+      (err instanceof Error ? err.message : "Failed to load user");
+    throw new Error(message);
+  }
+}

--- a/swagger.json
+++ b/swagger.json
@@ -16,6 +16,31 @@
             "description": "OK"
           }
         }
+      },
+      "post": {
+        "tags": [
+          "Album"
+        ],
+        "operationId": "CreateAlbum",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": { "type": "string" }
+                },
+                "required": ["title"]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/Album/{id}": {
@@ -40,19 +65,20 @@
             "description": "OK"
           }
         }
-      }
-    },
-    "/Album/CreateAlbum": {
-      "post": {
+      },
+      "delete": {
         "tags": [
           "Album"
         ],
+        "operationId": "DeleteAlbum",
         "parameters": [
           {
-            "name": "albumName",
-            "in": "query",
+            "name": "id",
+            "in": "path",
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             }
           }
         ],

--- a/swagger.json
+++ b/swagger.json
@@ -10,10 +10,38 @@
         "tags": [
           "Album"
         ],
+        "summary": "Retrieves a list of available albums.",
+        "description": "This method returns all albums currently available in the system. If no albums are available,\r\n            the response will contain an empty list.",
         "operationId": "GetAlbums",
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlbumModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlbumModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlbumModel"
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -21,20 +49,49 @@
         "tags": [
           "Album"
         ],
-        "operationId": "CreateAlbum",
+        "summary": "Creates a new album with the specified name and associated photos.",
+        "description": "This method creates a new album and associates the specified photos with it.  The album is\r\n            created asynchronously, and the operation can be canceled using the provided ct.",
+        "parameters": [
+          {
+            "name": "albumName",
+            "in": "query",
+            "description": "The name of the album to create. Cannot be null or empty.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
+          "description": "An array of photo IDs to associate with the album. The array can be empty, but cannot be null.",
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "title": { "type": "string" }
-                },
-                "required": ["title"]
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -48,6 +105,8 @@
         "tags": [
           "Album"
         ],
+        "summary": "Retrieves an album by its unique identifier.",
+        "description": "The id must correspond to an existing album in the system. If the album does\r\n            not exist, the response will indicate an error.",
         "operationId": "GetAlbumById",
         "parameters": [
           {
@@ -55,26 +114,46 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumModel"
+                }
+              }
+            }
           }
         }
-      },
+      }
+    },
+    "/Album/{albumId}": {
       "delete": {
         "tags": [
           "Album"
         ],
-        "operationId": "DeleteAlbum",
+        "summary": "Deletes the album with the specified identifier.",
+        "description": "This operation is idempotent. If the specified album does not exist, the method still returns\r\n            Microsoft.AspNetCore.Mvc.NoContentResult.",
         "parameters": [
           {
-            "name": "id",
+            "name": "albumId",
             "in": "path",
+            "description": "The unique identifier of the album to delete.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -528,6 +607,33 @@
   },
   "components": {
     "schemas": {
+      "AlbumModel": {
+        "required": [
+          "id",
+          "title",
+          "photoCount"
+        ],
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "photoCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "thumbnailPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
       "AccessTokenResponse": {
         "required": [
           "accessToken",

--- a/swagger.json
+++ b/swagger.json
@@ -16,6 +16,27 @@
             "description": "OK"
           }
         }
+      },
+      "post": {
+        "tags": [
+          "Album"
+        ],
+        "operationId": "CreateAlbum",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAlbumRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/Album/{id}": {
@@ -32,27 +53,6 @@
             "schema": {
               "type": "integer",
               "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/Album/CreateAlbum": {
-      "post": {
-        "tags": [
-          "Album"
-        ],
-        "parameters": [
-          {
-            "name": "albumName",
-            "in": "query",
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -527,6 +527,14 @@
             "type": "string",
             "nullable": true
           }
+        },
+        "additionalProperties": false
+      },
+      "CreateAlbumRequest": {
+        "type": "object",
+        "required": ["title"],
+        "properties": {
+          "title": { "type": "string" }
         },
         "additionalProperties": false
       },

--- a/swagger.json
+++ b/swagger.json
@@ -16,27 +16,6 @@
             "description": "OK"
           }
         }
-      },
-      "post": {
-        "tags": [
-          "Album"
-        ],
-        "operationId": "CreateAlbum",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateAlbumRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
       }
     },
     "/Album/{id}": {
@@ -53,6 +32,27 @@
             "schema": {
               "type": "integer",
               "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/Album/CreateAlbum": {
+      "post": {
+        "tags": [
+          "Album"
+        ],
+        "parameters": [
+          {
+            "name": "albumName",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -530,14 +530,6 @@
         },
         "additionalProperties": false
       },
-      "CreateAlbumRequest": {
-        "type": "object",
-        "required": ["title"],
-        "properties": {
-          "title": { "type": "string" }
-        },
-        "additionalProperties": false
-      },
       "ForgotPasswordRequest": {
         "required": [
           "email"
@@ -586,7 +578,7 @@
             "nullable": true
           }
         },
-        "additionalProperties": { }
+        "additionalProperties": {}
       },
       "InfoRequest": {
         "type": "object",
@@ -784,7 +776,7 @@
   },
   "security": [
     {
-      "Bearer": [ ]
+      "Bearer": []
     }
   ]
 }

--- a/tests/unit/albums.test.ts
+++ b/tests/unit/albums.test.ts
@@ -56,14 +56,12 @@ describe("albums api", () => {
     const { createAlbum } = await import("../../src/shared/api/albums");
     await expect(createAlbum("New")).resolves.toEqual(mockAlbum);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe(
-      "https://api.example.com/Album/CreateAlbum?albumName=New",
-    );
+    expect(url).toBe("https://api.example.com/Album");
     expect(init?.method).toBe("POST");
-    expect(init?.body).toBeUndefined();
-    expect((init?.headers as Headers).get("Authorization")).toBe(
-      "Bearer token",
-    );
+    expect(init?.body).toBe(JSON.stringify({ title: "New" }));
+    const headers = init?.headers as Headers;
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("Authorization")).toBe("Bearer token");
   });
 
   it("deletes album", async () => {

--- a/tests/unit/albums.test.ts
+++ b/tests/unit/albums.test.ts
@@ -56,8 +56,12 @@ describe("albums api", () => {
     const { createAlbum } = await import("../../src/shared/api/albums");
     await expect(createAlbum("New")).resolves.toEqual(mockAlbum);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe("https://api.example.com/Album?albumName=New");
+    expect(url).toBe("https://api.example.com/Album");
     expect(init?.method).toBe("POST");
+    expect(init?.body).toBe(JSON.stringify({ title: "New" }));
+    expect((init?.headers as Headers).get("Content-Type")).toBe(
+      "application/json",
+    );
     expect((init?.headers as Headers).get("Authorization")).toBe(
       "Bearer token",
     );

--- a/tests/unit/albums.test.ts
+++ b/tests/unit/albums.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  delete (globalThis as any).document;
+});
+
+describe("albums api", () => {
+  it("fetches albums with auth header", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    (globalThis as any).document = { cookie: "accessToken=token" };
+    const mockAlbum = { id: 1, name: "Vacation" };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => [mockAlbum],
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { getAlbums } = await import("../../src/shared/api/albums");
+    await expect(getAlbums()).resolves.toEqual([mockAlbum]);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.example.com/Album");
+    expect(init?.method).toBe("GET");
+    expect((init?.headers as Headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+
+  it("creates album with name", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    (globalThis as any).document = { cookie: "accessToken=token" };
+    const mockAlbum = { id: 2, name: "New" };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => mockAlbum,
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { createAlbum } = await import("../../src/shared/api/albums");
+    await expect(createAlbum("New")).resolves.toEqual(mockAlbum);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.example.com/Album/CreateAlbum?albumName=New");
+    expect(init?.method).toBe("POST");
+    expect((init?.headers as Headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+
+  it("deletes album", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    (globalThis as any).document = { cookie: "accessToken=token" };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => undefined,
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { deleteAlbum } = await import("../../src/shared/api/albums");
+    await deleteAlbum(7);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.example.com/Album/7");
+    expect(init?.method).toBe("DELETE");
+    expect((init?.headers as Headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+
+  it("throws createAlbum error message", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad", 
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => ({ message: "fail" }),
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { createAlbum } = await import("../../src/shared/api/albums");
+    await expect(createAlbum("test")).rejects.toThrow("fail");
+  });
+});
+

--- a/tests/unit/albums.test.ts
+++ b/tests/unit/albums.test.ts
@@ -10,7 +10,12 @@ describe("albums api", () => {
   it("fetches albums with auth header", async () => {
     process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
     (globalThis as any).document = { cookie: "accessToken=token" };
-    const mockAlbum = { id: 1, name: "Vacation" };
+    const mockAlbum = {
+      id: 1,
+      title: "Vacation",
+      photoCount: 0,
+      thumbnailPath: null,
+    };
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -30,10 +35,15 @@ describe("albums api", () => {
     );
   });
 
-  it("creates album with name", async () => {
+  it("creates album with title", async () => {
     process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
     (globalThis as any).document = { cookie: "accessToken=token" };
-    const mockAlbum = { id: 2, name: "New" };
+    const mockAlbum = {
+      id: 2,
+      title: "New",
+      photoCount: 0,
+      thumbnailPath: null,
+    };
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,

--- a/tests/unit/albums.test.ts
+++ b/tests/unit/albums.test.ts
@@ -56,12 +56,11 @@ describe("albums api", () => {
     const { createAlbum } = await import("../../src/shared/api/albums");
     await expect(createAlbum("New")).resolves.toEqual(mockAlbum);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe("https://api.example.com/Album");
-    expect(init?.method).toBe("POST");
-    expect(init?.body).toBe(JSON.stringify({ title: "New" }));
-    expect((init?.headers as Headers).get("Content-Type")).toBe(
-      "application/json",
+    expect(url).toBe(
+      "https://api.example.com/Album/CreateAlbum?albumName=New",
     );
+    expect(init?.method).toBe("POST");
+    expect(init?.body).toBeUndefined();
     expect((init?.headers as Headers).get("Authorization")).toBe(
       "Bearer token",
     );
@@ -94,7 +93,7 @@ describe("albums api", () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 400,
-      statusText: "Bad", 
+      statusText: "Bad",
       headers: new Headers({ "Content-Type": "application/json" }),
       json: async () => ({ message: "fail" }),
       text: async () => "",

--- a/tests/unit/albums.test.ts
+++ b/tests/unit/albums.test.ts
@@ -56,7 +56,7 @@ describe("albums api", () => {
     const { createAlbum } = await import("../../src/shared/api/albums");
     await expect(createAlbum("New")).resolves.toEqual(mockAlbum);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe("https://api.example.com/Album/CreateAlbum?albumName=New");
+    expect(url).toBe("https://api.example.com/Album?albumName=New");
     expect(init?.method).toBe("POST");
     expect((init?.headers as Headers).get("Authorization")).toBe(
       "Bearer token",

--- a/tests/unit/users.test.ts
+++ b/tests/unit/users.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  delete (globalThis as any).document;
+});
+
+describe("users api", () => {
+  it("fetches current user with auth header", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    (globalThis as any).document = { cookie: "accessToken=token" };
+    const mockUser = { id: "1", userName: "tester", email: "t@test.com" };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => mockUser,
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { getCurrentUser } = await import("../../src/shared/api/users");
+    await expect(getCurrentUser()).resolves.toEqual(mockUser);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.example.com/User/currentUser");
+    expect(init?.method).toBe("GET");
+    expect((init?.headers as Headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+
+  it("throws getCurrentUser error message", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Bad",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => ({ message: "boom" }),
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { getCurrentUser } = await import("../../src/shared/api/users");
+    await expect(getCurrentUser()).rejects.toThrow("boom");
+  });
+});


### PR DESCRIPTION
## Summary
- add album API wrapper for listing, creating and deleting albums
- cover album API with unit tests
- load albums from API on albums view and add creation button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acc605f1d08322963e2776533b1dd2