### PR TITLE
Ensure consistent album cell sizing and improve album picker

### DIFF
--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -1,0 +1,35 @@
+.main {
+  padding: 2rem;
+}
+
+.title {
+  color: #00ff00;
+  margin-bottom: 1rem;
+}
+
+.status {
+  color: #00ff00;
+  margin-bottom: 1rem;
+}
+
+.photoGrid {
+  width: 100%;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.photoGrid img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.back {
+  display: inline-block;
+  margin-top: 1rem;
+  color: #00ff00;
+  border: 1px solid #00ff00;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}

--- a/app/albums/[id]/page.tsx
+++ b/app/albums/[id]/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/* eslint-disable @next/next/no-img-element */
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { getAlbum, getAlbumPhotos } from "@/shared/api/albums";
+import styles from "./album.module.css";
+
+type Props = { params: { id: string } };
+
+export default function AlbumView({ params }: Props) {
+  const id = Number(params.id);
+  const {
+    data: album,
+    isLoading: albumLoading,
+    isError: albumError,
+  } = useQuery({ queryKey: ["album", id], queryFn: () => getAlbum(id) });
+
+  const {
+    data: photos = [],
+    isLoading: photosLoading,
+    isError: photosError,
+  } = useQuery({
+    queryKey: ["albumPhotos", id],
+    queryFn: () => getAlbumPhotos(id),
+    enabled: !!album,
+  });
+
+  if (albumLoading) {
+    return <p className={styles.status}>Loading album...</p>;
+  }
+  if (albumError || !album) {
+    return <p className={styles.status}>Failed to load album</p>;
+  }
+
+  return (
+    <main className={styles.main}>
+      <h1 className={styles.title}>{album.title}</h1>
+      {photosLoading ? (
+        <p className={styles.status}>Loading photos...</p>
+      ) : photosError ? (
+        <p className={styles.status}>Failed to load photos</p>
+      ) : (
+        <div className={styles.photoGrid}>
+          {photos.map((photo) => (
+            <img
+              key={photo.id}
+              src={photo.photoUrl}
+              alt={photo.displayFileName}
+            />
+          ))}
+        </div>
+      )}
+      <Link href="/" className={styles.back}>
+        Back
+      </Link>
+    </main>
+  );
+}

--- a/app/albums/[id]/page.tsx
+++ b/app/albums/[id]/page.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable @next/next/no-img-element */
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { getAlbum, getAlbumPhotos } from "@/shared/api/albums";
+import { getAlbum } from "@/shared/api/albums";
 import styles from "./album.module.css";
 
 type Props = { params: { id: string } };
@@ -16,16 +16,6 @@ export default function AlbumView({ params }: Props) {
     isError: albumError,
   } = useQuery({ queryKey: ["album", id], queryFn: () => getAlbum(id) });
 
-  const {
-    data: photos = [],
-    isLoading: photosLoading,
-    isError: photosError,
-  } = useQuery({
-    queryKey: ["albumPhotos", id],
-    queryFn: () => getAlbumPhotos(id),
-    enabled: !!album,
-  });
-
   if (albumLoading) {
     return <p className={styles.status}>Loading album...</p>;
   }
@@ -36,21 +26,13 @@ export default function AlbumView({ params }: Props) {
   return (
     <main className={styles.main}>
       <h1 className={styles.title}>{album.title}</h1>
-      {photosLoading ? (
-        <p className={styles.status}>Loading photos...</p>
-      ) : photosError ? (
-        <p className={styles.status}>Failed to load photos</p>
-      ) : (
-        <div className={styles.photoGrid}>
-          {photos.map((photo) => (
-            <img
-              key={photo.id}
-              src={photo.photoUrl}
-              alt={photo.displayFileName}
-            />
-          ))}
-        </div>
-      )}
+      <div className={styles.photoGrid}>
+        {(album.albumPhotos ?? []).map((photo) => (
+          photo.blobUrl && (
+            <img key={photo.photoId} src={photo.blobUrl} alt="album photo" />
+          )
+        ))}
+      </div>
       <Link href="/" className={styles.back}>
         Back
       </Link>

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -128,13 +128,14 @@
 
 .albumItem img {
   width: 100%;
-  height: auto;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
   display: block;
 }
 
 .albumPlaceholder {
   width: 100%;
-  height: 150px;
+  aspect-ratio: 1 / 1;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -151,6 +152,9 @@
 
 .albumName {
   font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .albumCount {
@@ -332,10 +336,20 @@
   cursor: pointer;
 }
 
-.albumSelect img {
-  width: 40px;
-  height: 40px;
+.albumSelect img,
+.albumSelect .albumPlaceholder {
+  width: 32px;
+  height: 32px;
   object-fit: cover;
+  flex-shrink: 0;
+}
+
+.albumSelect span {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
 }
 
 @media (max-width: 600px) {

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -334,7 +334,7 @@
   border: 1px solid #00ff00;
   padding: 0.25rem;
   cursor: pointer;
-  color: #00ff00;
+  color: #fff;
 }
 
 .albumSelect img,

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -334,6 +334,7 @@
   border: 1px solid #00ff00;
   padding: 0.25rem;
   cursor: pointer;
+  color: #00ff00;
 }
 
 .albumSelect img,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -202,7 +202,11 @@ export default function Home() {
             )}
             <div className={styles.albumGrid}>
               {albums.map((album) => (
-                <div key={album.id} className={styles.albumItem}>
+                <Link
+                  key={album.id}
+                  href={`/albums/${album.id}`}
+                  className={styles.albumItem}
+                >
                   {album.thumbnailPath ? (
                     <img src={album.thumbnailPath} alt={album.title} />
                   ) : (
@@ -214,7 +218,7 @@ export default function Home() {
                       {album.photoCount} photos
                     </span>
                   </div>
-                </div>
+                </Link>
               ))}
             </div>
           </>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -157,8 +157,8 @@ export default function Home() {
               {photos.map((photo, i) => (
                 <img
                   key={photo.id}
-                  src={photo.photoUrl}
-                  alt={photo.displayFileName}
+                  src={photo.photoUrl ?? ""}
+                  alt={photo.displayFileName ?? ""}
                   onClick={() => setSelectedIndex(i)}
                 />
               ))}
@@ -258,8 +258,8 @@ export default function Home() {
               ×
             </button>
             <img
-              src={selectedPhoto.photoUrl}
-              alt={selectedPhoto.displayFileName}
+              src={selectedPhoto.photoUrl ?? ""}
+              alt={selectedPhoto.displayFileName ?? ""}
               className={styles.previewImage}
             />
             <div className={styles.previewMenuWrapper}>

--- a/src/shared/api/generated/index.ts
+++ b/src/shared/api/generated/index.ts
@@ -8,7 +8,9 @@ export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
 export type { AccessTokenResponse } from './models/AccessTokenResponse';
+export type { AlbumItemModel } from './models/AlbumItemModel';
 export type { AlbumModel } from './models/AlbumModel';
+export type { AlbumPhotoData } from './models/AlbumPhotoData';
 export type { ForgotPasswordRequest } from './models/ForgotPasswordRequest';
 export type { HttpValidationProblemDetails } from './models/HttpValidationProblemDetails';
 export type { InfoRequest } from './models/InfoRequest';

--- a/src/shared/api/generated/models/AlbumItemModel.ts
+++ b/src/shared/api/generated/models/AlbumItemModel.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { AlbumPhotoData } from './AlbumPhotoData';
-export type AlbumModel = {
+export type AlbumItemModel = {
     title?: string | null;
     photoCount?: number;
     thumbnailPath?: string | null;
     id?: number;
-    albumPhotos?: Array<AlbumPhotoData> | null;
 };
 

--- a/src/shared/api/generated/models/AlbumPhotoData.ts
+++ b/src/shared/api/generated/models/AlbumPhotoData.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type AlbumPhotoData = {
+    photoId?: number;
+    blobUrl?: string | null;
+};
+

--- a/src/shared/api/generated/services/AlbumPhotosService.ts
+++ b/src/shared/api/generated/services/AlbumPhotosService.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AlbumModel } from '../models/AlbumModel';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -69,6 +70,25 @@ export class AlbumPhotosService {
             path: {
                 'albumId': albumId,
                 'photoId': photoId,
+            },
+        });
+    }
+    /**
+     * Retrieves an album by its unique identifier.
+     * The id must correspond to an existing album in the system. If the album does
+     * not exist, the response will indicate an error.
+     * @param id The unique identifier of the album to retrieve.
+     * @returns AlbumModel OK
+     * @throws ApiError
+     */
+    public static getAlbumById(
+        id: number,
+    ): CancelablePromise<AlbumModel> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/AlbumPhotos/{id}/photos',
+            path: {
+                'id': id,
             },
         });
     }

--- a/src/shared/api/generated/services/AlbumService.ts
+++ b/src/shared/api/generated/services/AlbumService.ts
@@ -2,20 +2,19 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { AlbumModel } from '../models/AlbumModel';
+import type { AlbumItemModel } from '../models/AlbumItemModel';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
-
 export class AlbumService {
     /**
      * Retrieves a list of available albums.
      * This method returns all albums currently available in the system. If no albums are available,
      * the response will contain an empty list.
-     * @returns AlbumModel OK
+     * @returns AlbumItemModel OK
      * @throws ApiError
      */
-    public static getAlbums(): CancelablePromise<Array<AlbumModel>> {
+    public static getAlbums(): CancelablePromise<Array<AlbumItemModel>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/Album',
@@ -42,25 +41,6 @@ export class AlbumService {
             },
             body: requestBody,
             mediaType: 'application/json',
-        });
-    }
-    /**
-     * Retrieves an album by its unique identifier.
-     * The id must correspond to an existing album in the system. If the album does
-     * not exist, the response will indicate an error.
-     * @param id The unique identifier of the album to retrieve.
-     * @returns AlbumModel OK
-     * @throws ApiError
-     */
-    public static getAlbumById(
-        id: number,
-    ): CancelablePromise<AlbumModel> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/Album/{id}',
-            path: {
-                'id': id,
-            },
         });
     }
     /**

--- a/src/shared/api/photos.ts
+++ b/src/shared/api/photos.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { API_BASE_URL } from "../config";
-import { getCookie } from "../auth/session";
+import { getCookie, setAuthSession } from "../auth/session";
+import { refreshAccessToken } from "./auth";
 import { OpenAPI, PhotoService } from "./generated";
 
 OpenAPI.BASE = API_BASE_URL;
@@ -16,10 +17,10 @@ const PhotoMetadataSchema = z.object({
 
 export const PhotoSchema = z.object({
   id: z.number(),
-  displayFileName: z.string(),
-  photoUrl: z.string().url(),
+  displayFileName: z.string().nullable(),
+  photoUrl: z.string().url().nullable(),
   blobId: z.string(),
-  userId: z.string(),
+  userId: z.string().nullable(),
   createdAt: z.string(),
   photoMetadata: PhotoMetadataSchema,
 });
@@ -32,7 +33,28 @@ export async function getPhotos(): Promise<Photo[]> {
     const res = await PhotoService.latestPhotos();
     return PhotosSchema.parse(res);
   } catch (err) {
+    const status = (err as any)?.status as number | undefined;
     const body = (err as any)?.body as { message?: string } | undefined;
+    if (status === 401 && body?.message === "expired") {
+      const refreshToken = getCookie("refreshToken");
+      const username = getCookie("username") || "";
+      if (refreshToken) {
+        try {
+          const tokens = await refreshAccessToken(refreshToken);
+          setAuthSession(tokens.accessToken, tokens.refreshToken ?? refreshToken, username);
+          const retry = await PhotoService.latestPhotos();
+          return PhotosSchema.parse(retry);
+        } catch (refreshErr) {
+          const rBody = (refreshErr as any)?.body as { message?: string } | undefined;
+          const rMessage =
+            rBody?.message ??
+            (refreshErr instanceof Error
+              ? refreshErr.message
+              : "Failed to load photos");
+          throw new Error(rMessage);
+        }
+      }
+    }
     const message =
       body?.message ??
       (err instanceof Error ? err.message : "Failed to load photos");

--- a/src/shared/api/photos.ts
+++ b/src/shared/api/photos.ts
@@ -41,7 +41,14 @@ export async function getPhotos(): Promise<Photo[]> {
       if (refreshToken) {
         try {
           const tokens = await refreshAccessToken(refreshToken);
-          setAuthSession(tokens.accessToken, tokens.refreshToken ?? refreshToken, username);
+          if (!tokens.accessToken) {
+            throw new Error("Missing access token");
+          }
+          setAuthSession(
+            tokens.accessToken,
+            tokens.refreshToken ?? refreshToken,
+            username,
+          );
           const retry = await PhotoService.latestPhotos();
           return PhotosSchema.parse(retry);
         } catch (refreshErr) {

--- a/src/shared/api/photos.ts
+++ b/src/shared/api/photos.ts
@@ -14,7 +14,7 @@ const PhotoMetadataSchema = z.object({
   isoCount: z.number(),
 });
 
-const PhotoSchema = z.object({
+export const PhotoSchema = z.object({
   id: z.number(),
   displayFileName: z.string(),
   photoUrl: z.string().url(),

--- a/swagger.json
+++ b/swagger.json
@@ -21,7 +21,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/AlbumModel"
+                    "$ref": "#/components/schemas/AlbumItemModel"
                   }
                 }
               },
@@ -29,7 +29,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/AlbumModel"
+                    "$ref": "#/components/schemas/AlbumItemModel"
                   }
                 }
               },
@@ -37,7 +37,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/AlbumModel"
+                    "$ref": "#/components/schemas/AlbumItemModel"
                   }
                 }
               }
@@ -96,57 +96,6 @@
         "responses": {
           "200": {
             "description": "OK"
-          }
-        }
-      }
-    },
-    "/Album/{id}": {
-      "get": {
-        "tags": [
-          "Album"
-        ],
-        "summary": "Retrieves an album by its unique identifier.",
-        "description": "The id must correspond to an existing album in the system. If the album does\r\n            not exist, the response will indicate an error.",
-        "operationId": "GetAlbumById",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "query",
-            "description": "The unique identifier of the album to retrieve.",
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/AlbumModel"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AlbumModel"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AlbumModel"
-                }
-              }
-            }
           }
         }
       }
@@ -297,6 +246,50 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      }
+    },
+    "/AlbumPhotos/{id}/photos": {
+      "get": {
+        "tags": [
+          "AlbumPhotos"
+        ],
+        "summary": "Retrieves an album by its unique identifier.",
+        "description": "The id must correspond to an existing album in the system. If the album does\r\n            not exist, the response will indicate an error.",
+        "operationId": "GetAlbumById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the album to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumModel"
+                }
+              }
+            }
           }
         }
       }
@@ -850,6 +843,28 @@
         },
         "additionalProperties": false
       },
+      "AlbumItemModel": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "photoCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "thumbnailPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
       "AlbumModel": {
         "type": "object",
         "properties": {
@@ -868,6 +883,27 @@
           "id": {
             "type": "integer",
             "format": "int64"
+          },
+          "albumPhotos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlbumPhotoData"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlbumPhotoData": {
+        "type": "object",
+        "properties": {
+          "photoId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "blobUrl": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/tests/unit/albums.test.ts
+++ b/tests/unit/albums.test.ts
@@ -63,6 +63,43 @@ describe("albums api", () => {
     );
   });
 
+  it("fetches photos for an album", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    (globalThis as any).document = { cookie: "accessToken=token" };
+    const mockPhoto = {
+      id: 4,
+      displayFileName: "p.jpg",
+      photoUrl: "https://cdn.example.com/p.jpg",
+      blobId: "b1",
+      userId: "u1",
+      createdAt: "2024-01-01",
+      photoMetadata: {
+        cameraModel: "cam",
+        aperture: "f/1.8",
+        shutterTime: "1/100",
+        focusRange: 10,
+        isoCount: 100,
+      },
+    };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => [mockPhoto],
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { getAlbumPhotos } = await import("../../src/shared/api/albums");
+    await expect(getAlbumPhotos(9)).resolves.toEqual([mockPhoto]);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.example.com/AlbumPhotos/9/photos");
+    expect(init?.method).toBe("GET");
+    expect((init?.headers as Headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+  });
+
   it("creates album with query name and photo ids", async () => {
     process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
     (globalThis as any).document = { cookie: "accessToken=token" };

--- a/tests/unit/albums.test.ts
+++ b/tests/unit/albums.test.ts
@@ -43,6 +43,9 @@ describe("albums api", () => {
       title: "Trip",
       photoCount: 0,
       thumbnailPath: null,
+      albumPhotos: [
+        { photoId: 1, blobUrl: "https://cdn.example.com/p.jpg" },
+      ],
     };
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -56,44 +59,7 @@ describe("albums api", () => {
     const { getAlbum } = await import("../../src/shared/api/albums");
     await expect(getAlbum(3)).resolves.toEqual(mockAlbum);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe("https://api.example.com/Album/3");
-    expect(init?.method).toBe("GET");
-    expect((init?.headers as Headers).get("Authorization")).toBe(
-      "Bearer token",
-    );
-  });
-
-  it("fetches photos for an album", async () => {
-    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
-    (globalThis as any).document = { cookie: "accessToken=token" };
-    const mockPhoto = {
-      id: 4,
-      displayFileName: "p.jpg",
-      photoUrl: "https://cdn.example.com/p.jpg",
-      blobId: "b1",
-      userId: "u1",
-      createdAt: "2024-01-01",
-      photoMetadata: {
-        cameraModel: "cam",
-        aperture: "f/1.8",
-        shutterTime: "1/100",
-        focusRange: 10,
-        isoCount: 100,
-      },
-    };
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers({ "Content-Type": "application/json" }),
-      json: async () => [mockPhoto],
-      text: async () => "",
-    });
-    (global as any).fetch = mockFetch;
-    const { getAlbumPhotos } = await import("../../src/shared/api/albums");
-    await expect(getAlbumPhotos(9)).resolves.toEqual([mockPhoto]);
-    const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe("https://api.example.com/AlbumPhotos/9/photos");
+    expect(url).toBe("https://api.example.com/AlbumPhotos/3/photos");
     expect(init?.method).toBe("GET");
     expect((init?.headers as Headers).get("Authorization")).toBe(
       "Bearer token",


### PR DESCRIPTION
## Summary
- enforce square thumbnails and truncate names so album tiles stay uniform
- shrink album picker thumbnails and let names take priority for readability

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm format` *(fails: Command "format" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c8c1c648322b58d43b240ae01af