### PR TITLE
feat: add masonry layout to photo grids

### DIFF
--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -72,9 +72,6 @@
   position: relative;
   width: 100vw;
   height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   overflow: hidden;
 }
 

--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -61,7 +61,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.8);
+  background: #000;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -72,19 +72,33 @@
   position: relative;
   width: 100vw;
   height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .previewImage {
-  width: 100%;
-  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
   object-fit: contain;
   display: block;
 }
 
-.closePreview {
+.topBar {
   position: absolute;
-  top: 0.5rem;
-  left: 0.5rem;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.topBar button {
   background: none;
   border: none;
   color: #fff;
@@ -109,4 +123,10 @@
 
 .nextButton {
   right: 1rem;
+}
+
+@media (max-width: 600px) {
+  .navButton {
+    display: none;
+  }
 }

--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -12,16 +12,29 @@
   margin-bottom: 1rem;
 }
 
+/* Masonry-style photo grid for album view */
 .photoGrid {
+  column-count: 2;
+  column-gap: 0.5rem;
   width: 100%;
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+@media (min-width: 768px) {
+  .photoGrid {
+    column-count: 3;
+  }
+}
+
+@media (min-width: 1280px) {
+  .photoGrid {
+    column-count: 4;
+  }
 }
 
 .photoGrid img {
   width: 100%;
-  height: auto;
+  margin-bottom: 0.5rem;
+  break-inside: avoid;
   display: block;
 }
 

--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -75,14 +75,20 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
+}
+
+.previewTrack {
+  display: flex;
+  height: 100%;
+  transition: transform 0.3s ease;
 }
 
 .previewImage {
-  max-width: 100%;
-  max-height: 100%;
-  width: auto;
-  height: auto;
+  width: 100vw;
+  height: 100vh;
   object-fit: contain;
+  flex-shrink: 0;
   display: block;
 }
 

--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -53,3 +53,60 @@
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
 }
+
+/* Photo preview overlay */
+.photoPreviewOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.photoPreview {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+}
+
+.previewImage {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+.closePreview {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.navButton {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  cursor: pointer;
+}
+
+.prevButton {
+  left: 1rem;
+}
+
+.nextButton {
+  right: 1rem;
+}

--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -99,6 +99,7 @@
   justify-content: space-between;
   padding: 0.5rem;
   background: rgba(0, 0, 0, 0.6);
+  z-index: 1;
 }
 
 .topBar button {

--- a/app/albums/[id]/page.tsx
+++ b/app/albums/[id]/page.tsx
@@ -142,17 +142,27 @@ export default function AlbumView({ params }: Props) {
                 ←
               </button>
             </div>
-            <img
-              src={selectedPhoto.blobUrl}
-              alt="album photo"
-              className={styles.previewImage}
-            />
+            <div
+              className={styles.previewTrack}
+              style={{ transform: `translateX(-${selectedIndex! * 100}%)` }}
+            >
+              {photos.map((photo) => (
+                photo.blobUrl && (
+                  <img
+                    key={photo.photoId}
+                    src={photo.blobUrl}
+                    alt="album photo"
+                    className={styles.previewImage}
+                  />
+                )
+              ))}
+            </div>
           </div>
-          <button
-            className={`${styles.navButton} ${styles.nextButton}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              showNextPhoto();
+        <button
+          className={`${styles.navButton} ${styles.nextButton}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            showNextPhoto();
             }}
             aria-label="Next photo"
           >

--- a/app/albums/[id]/page.tsx
+++ b/app/albums/[id]/page.tsx
@@ -144,7 +144,7 @@ export default function AlbumView({ params }: Props) {
             </div>
             <div
               className={styles.previewTrack}
-              style={{ transform: `translateX(-${selectedIndex! * 100}%)` }}
+              style={{ transform: `translateX(-${selectedIndex! * 100}vw)` }}
             >
               {photos.map((photo) => (
                 photo.blobUrl && (

--- a/app/albums/[id]/page.tsx
+++ b/app/albums/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 /* eslint-disable @next/next/no-img-element */
 import Link from "next/link";
-import { useCallback, useState } from "react";
+import { useCallback, useState, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getAlbum, addPhotosToAlbum } from "@/shared/api/albums";
 import { uploadPhotos } from "@/shared/api/photos";
@@ -40,6 +40,25 @@ export default function AlbumView({ params }: Props) {
       ),
     [photos.length],
   );
+
+  const touchStartX = useRef<number | null>(null);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const delta = e.changedTouches[0].clientX - touchStartX.current;
+    if (Math.abs(delta) > 50) {
+      if (delta < 0) {
+        showNextPhoto();
+      } else {
+        showPrevPhoto();
+      }
+    }
+    touchStartX.current = null;
+  };
 
   const handlePhotoUpload = async (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -112,13 +131,17 @@ export default function AlbumView({ params }: Props) {
           <div
             className={styles.photoPreview}
             onClick={(e) => e.stopPropagation()}
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
           >
-            <button
-              className={styles.closePreview}
-              onClick={() => setSelectedIndex(null)}
-            >
-              ×
-            </button>
+            <div className={styles.topBar}>
+              <button
+                onClick={() => setSelectedIndex(null)}
+                aria-label="Close preview"
+              >
+                ←
+              </button>
+            </div>
             <img
               src={selectedPhoto.blobUrl}
               alt="album photo"

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -273,9 +273,6 @@
   position: relative;
   width: 100vw;
   height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   overflow: hidden;
 }
 

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -262,7 +262,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.8);
+  background: #000;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -273,19 +273,33 @@
   position: relative;
   width: 100vw;
   height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .previewImage {
-  width: 100%;
-  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
   object-fit: contain;
   display: block;
 }
 
-.closePreview {
+.topBar {
   position: absolute;
-  top: 0.5rem;
-  left: 0.5rem;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.topBar button {
   background: none;
   border: none;
   color: #fff;
@@ -294,9 +308,7 @@
 }
 
 .previewMenuWrapper {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+  position: relative;
 }
 
 .menuButton {
@@ -310,7 +322,7 @@
 .menuDropdown {
   position: absolute;
   right: 0;
-  margin-top: 0.5rem;
+  top: 100%;
   background: #000;
   border: 1px solid #00ff00;
   border-radius: 4px;
@@ -406,5 +418,9 @@
 
   .nav {
     flex-direction: row;
+  }
+
+  .navButton {
+    display: none;
   }
 }

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -276,14 +276,20 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
+}
+
+.previewTrack {
+  display: flex;
+  height: 100%;
+  transition: transform 0.3s ease;
 }
 
 .previewImage {
-  max-width: 100%;
-  max-height: 100%;
-  width: auto;
-  height: auto;
+  width: 100vw;
+  height: 100vh;
   object-fit: contain;
+  flex-shrink: 0;
   display: block;
 }
 

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -300,6 +300,7 @@
   justify-content: space-between;
   padding: 0.5rem;
   background: rgba(0, 0, 0, 0.6);
+  z-index: 1;
 }
 
 .topBar button {

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -262,18 +262,19 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 50;
+  z-index: 200;
 }
 
 .photoPreview {
   position: relative;
-  max-width: 90vw;
-  max-height: 90vh;
+  width: 100vw;
+  height: 100vh;
 }
 
 .previewImage {
-  max-width: 100%;
-  max-height: 100%;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
   display: block;
 }
 

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -104,18 +104,39 @@
   padding: 2rem;
 }
 
-.photoGrid,
+
+/* Masonry-style photo grid */
+.photoGrid {
+  column-count: 2;
+  column-gap: 0.5rem;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .photoGrid {
+    column-count: 3;
+  }
+}
+
+@media (min-width: 1280px) {
+  .photoGrid {
+    column-count: 4;
+  }
+}
+
+.photoGrid img {
+  width: 100%;
+  margin-bottom: 0.5rem;
+  break-inside: avoid;
+  display: block;
+}
+
+/* Album grid retains traditional grid layout */
 .albumGrid {
   width: 100%;
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-}
-
-.photoGrid img {
-  width: 100%;
-  height: auto;
-  display: block;
 }
 
 .albumItem {

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -136,20 +136,20 @@
   width: 100%;
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
 }
 
 .albumItem {
-  border: 1px solid #00ff00;
-  border-radius: 4px;
+  position: relative;
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
+  border-radius: 8px;
+  aspect-ratio: 4 / 3;
+  display: block;
 }
 
 .albumItem img {
   width: 100%;
-  aspect-ratio: 1 / 1;
+  height: 100%;
   object-fit: cover;
   display: block;
 }
@@ -163,7 +163,7 @@
 
 .albumPlaceholder {
   width: 100%;
-  aspect-ratio: 1 / 1;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -172,10 +172,13 @@
 }
 
 .albumInfo {
+  position: absolute;
+  inset: auto 0 0 0;
   padding: 0.5rem;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0));
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  color: #fff;
 }
 
 .albumName {
@@ -187,6 +190,7 @@
 
 .albumCount {
   font-size: 0.875rem;
+  opacity: 0.8;
 }
 
 .createAlbum {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -328,11 +328,19 @@ export default function Home() {
                 )}
               </div>
             </div>
-            <img
-              src={selectedPhoto.photoUrl ?? ""}
-              alt={selectedPhoto.displayFileName ?? ""}
-              className={styles.previewImage}
-            />
+            <div
+              className={styles.previewTrack}
+              style={{ transform: `translateX(-${selectedIndex! * 100}%)` }}
+            >
+              {photos.map((photo) => (
+                <img
+                  key={photo.id}
+                  src={photo.photoUrl ?? ""}
+                  alt={photo.displayFileName ?? ""}
+                  className={styles.previewImage}
+                />
+              ))}
+            </div>
           </div>
           <button
             className={`${styles.navButton} ${styles.nextButton}`}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -330,7 +330,7 @@ export default function Home() {
             </div>
             <div
               className={styles.previewTrack}
-              style={{ transform: `translateX(-${selectedIndex! * 100}%)` }}
+              style={{ transform: `translateX(-${selectedIndex! * 100}vw)` }}
             >
               {photos.map((photo) => (
                 <img


### PR DESCRIPTION
## Summary
- restyle main photo grid with responsive masonry columns
- apply the same masonry layout to album photo grids

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to load url axios in tests/unit/photos.test.ts)*
- `pnpm test:unit` *(fails: Command "test:unit" not found)*
- `pnpm typecheck` *(fails: Command "typecheck" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb6f766988322bc7395d1f66a4ab1