### PR TITLE
feat: add photo pagination

### DIFF
--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -12,17 +12,29 @@
   margin-bottom: 1rem;
 }
 
-/* Responsive photo grid for album view ordered left-to-right */
+/* Masonry-style photo grid for album view */
 .photoGrid {
+  column-count: 2;
+  column-gap: 0.5rem;
   width: 100%;
-  display: grid;
-  gap: 0.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+@media (min-width: 768px) {
+  .photoGrid {
+    column-count: 3;
+  }
+}
+
+@media (min-width: 1280px) {
+  .photoGrid {
+    column-count: 4;
+  }
 }
 
 .photoGrid img {
   width: 100%;
-  height: auto;
+  margin-bottom: 0.5rem;
+  break-inside: avoid;
   display: block;
 }
 

--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -12,29 +12,17 @@
   margin-bottom: 1rem;
 }
 
-/* Masonry-style photo grid for album view */
+/* Responsive photo grid for album view ordered left-to-right */
 .photoGrid {
-  column-count: 2;
-  column-gap: 0.5rem;
   width: 100%;
-}
-
-@media (min-width: 768px) {
-  .photoGrid {
-    column-count: 3;
-  }
-}
-
-@media (min-width: 1280px) {
-  .photoGrid {
-    column-count: 4;
-  }
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 }
 
 .photoGrid img {
   width: 100%;
-  margin-bottom: 0.5rem;
-  break-inside: avoid;
+  height: auto;
   display: block;
 }
 

--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -12,29 +12,34 @@
   margin-bottom: 1rem;
 }
 
-/* Masonry-style photo grid for album view */
+/* Masonry-style photo grid with left-to-right flow */
 .photoGrid {
-  column-count: 2;
-  column-gap: 0.5rem;
+  display: grid;
   width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-auto-rows: 10px;
+  grid-auto-flow: dense;
 }
 
 @media (min-width: 768px) {
   .photoGrid {
-    column-count: 3;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
 }
 
 @media (min-width: 1280px) {
   .photoGrid {
-    column-count: 4;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   }
 }
 
-.photoGrid img {
+.photoItem {
   width: 100%;
-  margin-bottom: 0.5rem;
-  break-inside: avoid;
+}
+
+.photoItem img {
+  width: 100%;
   display: block;
 }
 

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -108,17 +108,29 @@
 }
 
 
-/* Responsive photo grid ordered left-to-right */
+/* Masonry-style photo grid */
 .photoGrid {
+  column-count: 2;
+  column-gap: 0.5rem;
   width: 100%;
-  display: grid;
-  gap: 0.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+@media (min-width: 768px) {
+  .photoGrid {
+    column-count: 3;
+  }
+}
+
+@media (min-width: 1280px) {
+  .photoGrid {
+    column-count: 4;
+  }
 }
 
 .photoGrid img {
   width: 100%;
-  height: auto;
+  margin-bottom: 0.5rem;
+  break-inside: avoid;
   display: block;
 }
 

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -108,29 +108,17 @@
 }
 
 
-/* Masonry-style photo grid */
+/* Responsive photo grid ordered left-to-right */
 .photoGrid {
-  column-count: 2;
-  column-gap: 0.5rem;
   width: 100%;
-}
-
-@media (min-width: 768px) {
-  .photoGrid {
-    column-count: 3;
-  }
-}
-
-@media (min-width: 1280px) {
-  .photoGrid {
-    column-count: 4;
-  }
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 }
 
 .photoGrid img {
   width: 100%;
-  margin-bottom: 0.5rem;
-  break-inside: avoid;
+  height: auto;
   display: block;
 }
 

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -108,29 +108,34 @@
 }
 
 
-/* Masonry-style photo grid */
+/* Masonry-style photo grid with left-to-right flow */
 .photoGrid {
-  column-count: 2;
-  column-gap: 0.5rem;
+  display: grid;
   width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-auto-rows: 10px;
+  grid-auto-flow: dense;
 }
 
 @media (min-width: 768px) {
   .photoGrid {
-    column-count: 3;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
 }
 
 @media (min-width: 1280px) {
   .photoGrid {
-    column-count: 4;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   }
 }
 
-.photoGrid img {
+.photoItem {
   width: 100%;
-  margin-bottom: 0.5rem;
-  break-inside: avoid;
+}
+
+.photoItem img {
+  width: 100%;
   display: block;
 }
 

--- a/src/shared/api/photos.ts
+++ b/src/shared/api/photos.ts
@@ -37,9 +37,12 @@ const UploadPhotoResultSchema = z.union([
   z.coerce.number().transform((id) => ({ id })),
 ]);
 
-export async function getPhotos(): Promise<Photo[]> {
+export async function getPhotos(
+  offset = 0,
+  pageSize = 20,
+): Promise<Photo[]> {
   try {
-    const res = await PhotoService.latestPhotos();
+    const res = await PhotoService.latestPhotos(offset, pageSize);
     return PhotosSchema.parse(res);
   } catch (err) {
     const status = (err as any)?.status as number | undefined;
@@ -58,10 +61,12 @@ export async function getPhotos(): Promise<Photo[]> {
             tokens.refreshToken ?? refreshToken,
             username,
           );
-          const retry = await PhotoService.latestPhotos();
+          const retry = await PhotoService.latestPhotos(offset, pageSize);
           return PhotosSchema.parse(retry);
         } catch (refreshErr) {
-          const rBody = (refreshErr as any)?.body as { message?: string } | undefined;
+          const rBody = (refreshErr as any)?.body as {
+            message?: string;
+          } | undefined;
           const rMessage =
             rBody?.message ??
             (refreshErr instanceof Error

--- a/tests/unit/photos.test.ts
+++ b/tests/unit/photos.test.ts
@@ -62,10 +62,33 @@ describe("getPhotos", () => {
     (global as any).fetch = mockFetch;
     const { getPhotos } = await import("../../src/shared/api/photos");
     await expect(getPhotos()).resolves.toEqual([mockPhoto]);
-    const [, init] = mockFetch.mock.calls[0];
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      "https://api.example.com/Photo?offset=0&pageSize=20",
+    );
     expect(init?.method).toBe("GET");
     expect((init?.headers as Headers).get("Authorization")).toBe(
       "Bearer token",
+    );
+  });
+
+  it("supports custom offset and pageSize", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
+    setupDom({ accessToken: "token" });
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: async () => [],
+      text: async () => "",
+    });
+    (global as any).fetch = mockFetch;
+    const { getPhotos } = await import("../../src/shared/api/photos");
+    await expect(getPhotos(40, 10)).resolves.toEqual([]);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      "https://api.example.com/Photo?offset=40&pageSize=10",
     );
   });
 


### PR DESCRIPTION
## Summary
- add offset-based pagination to photo API client
- implement "Load more" paging on photo view
- style load more button and test query params
- auto-load next photo page when scrolling reaches the end

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck` *(fails: Command "typecheck" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed4380c4883228158b74bae9816f3