### PR TITLE
Use thumbnails for photo grids

### DIFF
--- a/app/albums/[id]/page.tsx
+++ b/app/albums/[id]/page.tsx
@@ -13,7 +13,7 @@ export default function AlbumView({ params }: Props) {
   const id = Number(params.id);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const gridRef = useRef<HTMLDivElement | null>(null);
-  
+
   const {
     data: album,
     isLoading: albumLoading,
@@ -21,8 +21,7 @@ export default function AlbumView({ params }: Props) {
   } = useQuery({ queryKey: ["album", id], queryFn: () => getAlbum(id) });
 
   const photos = useMemo(() => album?.albumPhotos ?? [], [album]);
-  const selectedPhoto =
-    selectedIndex !== null ? photos[selectedIndex] : null;
+  const selectedPhoto = selectedIndex !== null ? photos[selectedIndex] : null;
 
   const resizeAllGridItems = useCallback(() => {
     const grid = gridRef.current;
@@ -97,14 +96,14 @@ export default function AlbumView({ params }: Props) {
       <div className={styles.photoGrid} ref={gridRef}>
         {photos.map(
           (photo, i) =>
-            photo.blobUrl && (
+            (photo.thumbnailUrl || photo.blobUrl) && (
               <div
                 key={photo.photoId}
                 className={styles.photoItem}
                 onClick={() => setSelectedIndex(i)}
               >
                 <img
-                  src={photo.blobUrl}
+                  src={photo.thumbnailUrl ?? photo.blobUrl ?? ""}
                   alt="album photo"
                   onLoad={resizeAllGridItems}
                 />
@@ -145,23 +144,24 @@ export default function AlbumView({ params }: Props) {
               className={styles.previewTrack}
               style={{ transform: `translateX(-${selectedIndex! * 100}vw)` }}
             >
-              {photos.map((photo) => (
-                photo.blobUrl && (
-                  <img
-                    key={photo.photoId}
-                    src={photo.blobUrl}
-                    alt="album photo"
-                    className={styles.previewImage}
-                  />
-                )
-              ))}
+              {photos.map(
+                (photo) =>
+                  photo.blobUrl && (
+                    <img
+                      key={photo.photoId}
+                      src={photo.blobUrl}
+                      alt="album photo"
+                      className={styles.previewImage}
+                    />
+                  ),
+              )}
             </div>
           </div>
-        <button
-          className={`${styles.navButton} ${styles.nextButton}`}
-          onClick={(e) => {
-            e.stopPropagation();
-            showNextPhoto();
+          <button
+            className={`${styles.navButton} ${styles.nextButton}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              showNextPhoto();
             }}
             aria-label="Next photo"
           >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,11 @@
 /* eslint-disable @next/next/no-img-element */
 import Link from "next/link";
 import { useCallback, useEffect, useState, useRef, useMemo } from "react";
-import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import styles from "./home.module.css";
 import { getCookie, onAuthSessionChange } from "@/shared/auth/session";
 import { getPhotos } from "@/shared/api/photos";
@@ -89,8 +93,7 @@ export default function Home() {
     return () => observer.disconnect();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-  const selectedPhoto =
-    selectedIndex !== null ? photos[selectedIndex] : null;
+  const selectedPhoto = selectedIndex !== null ? photos[selectedIndex] : null;
 
   const {
     data: albums = [],
@@ -229,7 +232,7 @@ export default function Home() {
                     onClick={() => setSelectedIndex(i)}
                   >
                     <img
-                      src={photo.photoUrl ?? ""}
+                      src={photo.thumbnailUrl ?? photo.photoUrl ?? ""}
                       alt={photo.displayFileName ?? ""}
                       onLoad={resizeAllGridItems}
                     />
@@ -293,7 +296,8 @@ export default function Home() {
                   <div className={styles.albumInfo}>
                     <span className={styles.albumName}>{album.title}</span>
                     <span className={styles.albumCount}>
-                      {album.photoCount} {album.photoCount === 1 ? "photo" : "photos"}
+                      {album.photoCount}{" "}
+                      {album.photoCount === 1 ? "photo" : "photos"}
                     </span>
                   </div>
                 </Link>

--- a/src/shared/api/albums.ts
+++ b/src/shared/api/albums.ts
@@ -8,7 +8,8 @@ OpenAPI.TOKEN = async () => getCookie("accessToken") || "";
 
 const AlbumPhotoSchema = z.object({
   photoId: z.number(),
-  blobUrl: z.string().nullable(),
+  blobUrl: z.string().url().nullable(),
+  thumbnailUrl: z.string().url().nullable(),
 });
 
 const AlbumSchema = z.object({
@@ -105,6 +106,3 @@ export async function addPhotosToAlbum(
     throw new Error(message);
   }
 }
-
-
-

--- a/src/shared/api/generated/models/AlbumPhotoData.ts
+++ b/src/shared/api/generated/models/AlbumPhotoData.ts
@@ -3,7 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export type AlbumPhotoData = {
-    photoId?: number;
-    blobUrl?: string | null;
+  photoId?: number;
+  blobUrl?: string | null;
+  thumbnailUrl?: string | null;
 };
-

--- a/src/shared/api/generated/models/PhotoModel.ts
+++ b/src/shared/api/generated/models/PhotoModel.ts
@@ -2,14 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { PhotoMetadata } from './PhotoMetadata';
+import type { PhotoMetadata } from "./PhotoMetadata";
 export type PhotoModel = {
-    id?: number;
-    displayFileName?: string | null;
-    photoUrl?: string | null;
-    blobId?: string;
-    userId?: string | null;
-    createdAt?: string;
-    photoMetadata?: PhotoMetadata;
+  id?: number;
+  displayFileName?: string | null;
+  photoUrl?: string | null;
+  thumbnailUrl?: string | null;
+  blobId?: string;
+  userId?: string | null;
+  createdAt?: string;
+  photoMetadata?: PhotoMetadata;
 };
-

--- a/src/shared/api/photos.ts
+++ b/src/shared/api/photos.ts
@@ -20,6 +20,7 @@ export const PhotoSchema = z.object({
   id: z.number(),
   displayFileName: z.string().nullable(),
   photoUrl: z.string().url().nullable(),
+  thumbnailUrl: z.string().url().nullable(),
   blobId: z.string(),
   userId: z.string().nullable(),
   createdAt: z.string(),
@@ -37,10 +38,7 @@ const UploadPhotoResultSchema = z.union([
   z.coerce.number().transform((id) => ({ id })),
 ]);
 
-export async function getPhotos(
-  offset = 0,
-  pageSize = 20,
-): Promise<Photo[]> {
+export async function getPhotos(offset = 0, pageSize = 20): Promise<Photo[]> {
   try {
     const res = await PhotoService.latestPhotos(offset, pageSize);
     return PhotosSchema.parse(res);
@@ -64,9 +62,11 @@ export async function getPhotos(
           const retry = await PhotoService.latestPhotos(offset, pageSize);
           return PhotosSchema.parse(retry);
         } catch (refreshErr) {
-          const rBody = (refreshErr as any)?.body as {
-            message?: string;
-          } | undefined;
+          const rBody = (refreshErr as any)?.body as
+            | {
+                message?: string;
+              }
+            | undefined;
           const rMessage =
             rBody?.message ??
             (refreshErr instanceof Error
@@ -122,7 +122,9 @@ export async function uploadPhoto(
           );
           return await uploadPhoto(file, onProgress);
         } catch (refreshErr: any) {
-          const rBody = refreshErr?.response?.data as { message?: string } | undefined;
+          const rBody = refreshErr?.response?.data as
+            | { message?: string }
+            | undefined;
           const rMessage =
             rBody?.message ??
             (refreshErr instanceof Error

--- a/swagger.json
+++ b/swagger.json
@@ -95,7 +95,27 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            }
           }
         }
       }
@@ -120,8 +140,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK"
+          "204": {
+            "description": "No Content"
           }
         }
       }
@@ -178,8 +198,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "204": {
+            "description": "No Content"
           }
         }
       }
@@ -214,8 +234,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK"
+          "204": {
+            "description": "No Content"
           }
         }
       },
@@ -244,8 +264,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK"
+          "204": {
+            "description": "No Content"
           }
         }
       }
@@ -728,7 +748,24 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PhotoUploadResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PhotoUploadResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PhotoUploadResult"
+                }
+              }
+            }
           }
         }
       }
@@ -854,13 +891,13 @@
             "type": "integer",
             "format": "int32"
           },
-          "thumbnailPath": {
-            "type": "string",
-            "nullable": true
-          },
           "id": {
             "type": "integer",
             "format": "int64"
+          },
+          "thumbnailPath": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -902,6 +939,10 @@
             "format": "int64"
           },
           "blobUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "thumbnailUrl": {
             "type": "string",
             "nullable": true
           }
@@ -1060,6 +1101,10 @@
             "type": "string",
             "nullable": true
           },
+          "thumbnailUrl": {
+            "type": "string",
+            "nullable": true
+          },
           "blobId": {
             "type": "string",
             "format": "uuid"
@@ -1074,6 +1119,28 @@
           },
           "photoMetadata": {
             "$ref": "#/components/schemas/PhotoMetadata"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhotoUploadResult": {
+        "type": "object",
+        "properties": {
+          "blobUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "thumbnailBlobUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "blobId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "photoId": {
+            "type": "integer",
+            "format": "int64"
           }
         },
         "additionalProperties": false

--- a/tests/unit/albums.test.ts
+++ b/tests/unit/albums.test.ts
@@ -44,7 +44,11 @@ describe("albums api", () => {
       photoCount: 0,
       thumbnailPath: null,
       albumPhotos: [
-        { photoId: 1, blobUrl: "https://cdn.example.com/p.jpg" },
+        {
+          photoId: 1,
+          blobUrl: "https://cdn.example.com/p.jpg",
+          thumbnailUrl: "https://cdn.example.com/p_thumb.jpg",
+        },
       ],
     };
     const mockFetch = vi.fn().mockResolvedValue({
@@ -175,4 +179,3 @@ describe("albums api", () => {
     expect(init?.body).toBe(JSON.stringify([]));
   });
 });
-

--- a/tests/unit/photos.test.ts
+++ b/tests/unit/photos.test.ts
@@ -40,6 +40,8 @@ describe("getPhotos", () => {
       displayFileName: "no-signal.png",
       photoUrl:
         "https://lazystoragephotos001.blob.core.windows.net/photos/46ebce29-7465-4967-b2c6-07963943ca3e/0ae3bc43-bbf7-402c-a0bd-a08037fe821e.png",
+      thumbnailUrl:
+        "https://lazystoragephotos001.blob.core.windows.net/photos/46ebce29-7465-4967-b2c6-07963943ca3e/0ae3bc43-bbf7-402c-a0bd-a08037fe821e_thumb.png",
       blobId: "0ae3bc43-bbf7-402c-a0bd-a08037fe821e",
       userId: "46ebce29-7465-4967-b2c6-07963943ca3e",
       createdAt: "2024-09-18T14:02:53.1166667+00:00",
@@ -63,9 +65,7 @@ describe("getPhotos", () => {
     const { getPhotos } = await import("../../src/shared/api/photos");
     await expect(getPhotos()).resolves.toEqual([mockPhoto]);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe(
-      "https://api.example.com/Photo?offset=0&pageSize=20",
-    );
+    expect(url).toBe("https://api.example.com/Photo?offset=0&pageSize=20");
     expect(init?.method).toBe("GET");
     expect((init?.headers as Headers).get("Authorization")).toBe(
       "Bearer token",
@@ -87,9 +87,7 @@ describe("getPhotos", () => {
     const { getPhotos } = await import("../../src/shared/api/photos");
     await expect(getPhotos(40, 10)).resolves.toEqual([]);
     const [url] = mockFetch.mock.calls[0];
-    expect(url).toBe(
-      "https://api.example.com/Photo?offset=40&pageSize=10",
-    );
+    expect(url).toBe("https://api.example.com/Photo?offset=40&pageSize=10");
   });
 
   it("throws with server message", async () => {
@@ -107,7 +105,6 @@ describe("getPhotos", () => {
     const { getPhotos } = await import("../../src/shared/api/photos");
     await expect(getPhotos()).rejects.toThrow("boom");
   });
-
 });
 
 describe("uploadPhoto", () => {
@@ -141,17 +138,14 @@ describe("uploadPhoto", () => {
   it("throws server message", async () => {
     process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
     setupDom({ accessToken: "token" });
-    const post = vi
-      .fn()
-      .mockRejectedValue({
-        response: { status: 400, data: { message: "boom" } },
-      });
+    const post = vi.fn().mockRejectedValue({
+      response: { status: 400, data: { message: "boom" } },
+    });
     (axios.post as any) = post;
     const file = new File(["data"], "p.jpg", { type: "image/jpeg" });
     const { uploadPhoto } = await import("../../src/shared/api/photos");
     await expect(uploadPhoto(file)).rejects.toThrow("boom");
   });
-
 });
 
 describe("uploadPhotos", () => {
@@ -159,13 +153,13 @@ describe("uploadPhotos", () => {
     process.env.NEXT_PUBLIC_API_BASE_URL = "https://api.example.com";
     setupDom({ accessToken: "t" });
     let id = 1;
-    const post = vi.fn().mockImplementation(
-      (_url: string, _data: FormData, config: any) => {
+    const post = vi
+      .fn()
+      .mockImplementation((_url: string, _data: FormData, config: any) => {
         config.onUploadProgress({ loaded: 50, total: 100 });
         config.onUploadProgress({ loaded: 100, total: 100 });
         return Promise.resolve({ data: { id: id++ } });
-      },
-    );
+      });
     (axios.post as any) = post;
     const { uploadPhotos } = await import("../../src/shared/api/photos");
     const file1 = new File(["a"], "a.jpg", { type: "image/jpeg" });


### PR DESCRIPTION
## Summary
- refresh Swagger spec to include album photo thumbnails
- align album API schemas with `blobUrl`/`thumbnailUrl`
- display thumbnails in album grids with `blobUrl` fallback and use `blobUrl` for full-screen preview

## Testing
- `pnpm lint`
- `npx tsc -p tsconfig.json --noEmit && echo 'Typecheck passed'`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68af10bdac488322b9bedc8656c6bd04