### PR TITLE
Ensure photo preview controls visible and escapable

### DIFF
--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -126,9 +126,3 @@
 .nextButton {
   right: 1rem;
 }
-
-@media (max-width: 600px) {
-  .navButton {
-    display: none;
-  }
-}

--- a/app/albums/[id]/page.tsx
+++ b/app/albums/[id]/page.tsx
@@ -78,6 +78,21 @@ export default function AlbumView({ params }: Props) {
   };
 
   useEffect(() => {
+    if (selectedIndex === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight") {
+        showNextPhoto();
+      } else if (e.key === "ArrowLeft") {
+        showPrevPhoto();
+      } else if (e.key === "Escape") {
+        setSelectedIndex(null);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedIndex, showNextPhoto, showPrevPhoto]);
+
+  useEffect(() => {
     resizeAllGridItems();
     window.addEventListener("resize", resizeAllGridItems);
     return () => window.removeEventListener("resize", resizeAllGridItems);
@@ -128,11 +143,13 @@ export default function AlbumView({ params }: Props) {
           </button>
           <div
             className={styles.photoPreview}
-            onClick={(e) => e.stopPropagation()}
             onTouchStart={handleTouchStart}
             onTouchEnd={handleTouchEnd}
           >
-            <div className={styles.topBar}>
+            <div
+              className={styles.topBar}
+              onClick={(e) => e.stopPropagation()}
+            >
               <button
                 onClick={() => setSelectedIndex(null)}
                 aria-label="Close preview"
@@ -152,6 +169,7 @@ export default function AlbumView({ params }: Props) {
                       src={photo.blobUrl}
                       alt="album photo"
                       className={styles.previewImage}
+                      onClick={(e) => e.stopPropagation()}
                     />
                   ),
               )}

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -426,8 +426,4 @@
   .nav {
     flex-direction: row;
   }
-
-  .navButton {
-    display: none;
-  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -161,11 +161,19 @@ export default function Home() {
         showNextPhoto();
       } else if (e.key === "ArrowLeft") {
         showPrevPhoto();
+      } else if (e.key === "Escape") {
+        setSelectedIndex(null);
+        setMenuOpen(false);
+        setShowAlbumPicker(false);
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [selectedIndex, showNextPhoto, showPrevPhoto]);
+  }, [
+    selectedIndex,
+    showNextPhoto,
+    showPrevPhoto,
+  ]);
 
   if (!username) {
     const images = Array.from({ length: 6 }).map((_, i) => (
@@ -327,11 +335,13 @@ export default function Home() {
           </button>
           <div
             className={styles.photoPreview}
-            onClick={(e) => e.stopPropagation()}
             onTouchStart={handleTouchStart}
             onTouchEnd={handleTouchEnd}
           >
-            <div className={styles.topBar}>
+            <div
+              className={styles.topBar}
+              onClick={(e) => e.stopPropagation()}
+            >
               <button
                 onClick={() => {
                   setSelectedIndex(null);
@@ -374,6 +384,7 @@ export default function Home() {
                   src={photo.photoUrl ?? ""}
                   alt={photo.displayFileName ?? ""}
                   className={styles.previewImage}
+                  onClick={(e) => e.stopPropagation()}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary
- Keep photo navigation buttons visible on mobile
- Allow closing preview with Escape key or tapping outside image
- Support same closing behavior in album view

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm e2e` *(fails: Command "e2e" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af7dd748448322b77d4c3abd5f0860