### PR TITLE
Improve mobile responsiveness for small screens

### DIFF
--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -126,3 +126,9 @@
 .nextButton {
   right: 1rem;
 }
+
+@media (max-width: 600px) {
+  .main {
+    padding: 1rem;
+  }
+}

--- a/app/header.module.css
+++ b/app/header.module.css
@@ -2,11 +2,15 @@
   position: fixed;
   top: 0;
   right: 0;
+  left: 0;
+  width: 100%;
   padding: 1rem;
   z-index: 100;
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .userMenu {
@@ -42,4 +46,19 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .header {
+    justify-content: center;
+  }
+
+  .uploadProgress {
+    width: 100%;
+  }
+
+  .userMenu {
+    width: 100%;
+    justify-content: center;
+  }
 }

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -406,6 +406,10 @@
 }
 
 @media (max-width: 600px) {
+  .main {
+    padding: 1rem;
+  }
+
   .title {
     font-size: 2rem;
   }
@@ -425,5 +429,16 @@
 
   .nav {
     flex-direction: row;
+  }
+
+  .actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .login,
+  .register {
+    width: 100%;
+    text-align: center;
   }
 }


### PR DESCRIPTION
## Summary
- expand header to full width and wrap controls for narrow devices
- stack actions and reduce padding on home and album pages for smaller viewports

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b00b2d59308322905fbc7e601e6462