### PR TITLE
fix: prevent header overlap and show preview controls in Safari

### DIFF
--- a/app/albums/[id]/album.module.css
+++ b/app/albums/[id]/album.module.css
@@ -63,13 +63,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 200;
+  z-index: 1000;
 }
 
 .photoPreview {
   position: relative;
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 }
 
@@ -82,6 +83,7 @@
 .previewImage {
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   object-fit: contain;
   flex-shrink: 0;
   display: block;
@@ -96,6 +98,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem;
+  padding-top: calc(0.5rem + constant(safe-area-inset-top));
+  padding-top: calc(0.5rem + env(safe-area-inset-top));
   background: rgba(0, 0, 0, 0.6);
   z-index: 1;
 }

--- a/app/header.module.css
+++ b/app/header.module.css
@@ -1,8 +1,7 @@
 .header {
-  position: fixed;
+  position: -webkit-sticky;
+  position: sticky;
   top: 0;
-  right: 0;
-  left: 0;
   width: 100%;
   padding: 1rem;
   z-index: 100;

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -269,13 +269,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 200;
+  z-index: 1000;
 }
 
 .photoPreview {
   position: relative;
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 }
 
@@ -288,6 +289,7 @@
 .previewImage {
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   object-fit: contain;
   flex-shrink: 0;
   display: block;
@@ -302,6 +304,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem;
+  padding-top: calc(0.5rem + constant(safe-area-inset-top));
+  padding-top: calc(0.5rem + env(safe-area-inset-top));
   background: rgba(0, 0, 0, 0.6);
   z-index: 1;
 }


### PR DESCRIPTION
## Summary
- add webkit sticky positioning to keep header compatible across browsers
- adjust photo preview overlay for Safari safe area and dynamic viewport so controls stay visible

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b00cd23e1883228c9b66d3d9389872